### PR TITLE
Fix article title extraction in text chunks

### DIFF
--- a/src/searchpubmed/pubmed.py
+++ b/src/searchpubmed/pubmed.py
@@ -1332,7 +1332,7 @@ def get_jats_text_chunks(
         collect = False
         if tag == "p":
             collect = True
-        elif tag == "title" and not sec_stack and not captured_article_title:
+        elif tag in ("title", "article-title") and not sec_stack and not captured_article_title:
             collect = True
             captured_article_title = True
         elif tag == "caption":


### PR DESCRIPTION
## Summary
- capture `<article-title>` elements when extracting JATS text chunks

## Testing
- `python -m pytest tests/test_jats_chunks.py -vv` *(fails: No module named pytest)*